### PR TITLE
Add quickfire and treasure puzzles to chapter 1

### DIFF
--- a/math-rpg/src/game/chapters/chapter1.js
+++ b/math-rpg/src/game/chapters/chapter1.js
@@ -24,7 +24,16 @@ export const chapter1 = {
     },
     {
       type: 'narrative',
-      text: 'The beast withers. A rusted door stands ahead with a number pad.',
+      text: 'The beast withers. Water sirens flash as the tunnel starts flooding faster around you.',
+      meta: 'Stabilise the valves before the corridor fills.'
+    },
+    {
+      type: 'puzzle',
+      id: 'quickfire'
+    },
+    {
+      type: 'narrative',
+      text: 'With the pressure settled, a rusted door stands ahead with a number pad.',
       meta: 'Crack the lock.'
     },
     {
@@ -39,7 +48,16 @@ export const chapter1 = {
     },
     {
       type: 'narrative',
-      text: 'Beyond the door, a submerged tunnel gurgles. You find an oxygen tank from an earlier skirmish.',
+      text: 'Inside the chamber a barnacled treasure chest pulses with blue light.',
+      meta: 'The glyphs promise a cosmetic badge for the right code.'
+    },
+    {
+      type: 'puzzle',
+      id: 'treasure-chest'
+    },
+    {
+      type: 'narrative',
+      text: 'Whether the chest rewards you or explodes in spray, you press deeper into the ruins. A submerged tunnel gurgles nearby and an oxygen tank lies within reach.',
       meta: 'Time your swim.'
     },
     {

--- a/math-rpg/src/game/engine.js
+++ b/math-rpg/src/game/engine.js
@@ -1,6 +1,8 @@
 import { renderNarrative, renderChoices, setFeedback } from '../ui/ui.js';
 import { speak, narrationEnabled } from '../tts.js';
 import { oxygenPuzzle } from './puzzles/oxygen.js';
+import { quickfirePuzzle } from './puzzles/quickfire.js';
+import { treasureChestPuzzle } from './puzzles/treasureChest.js';
 
 export class Engine{
   constructor({screen, nextBtn, restartBtn, chapter}){
@@ -105,13 +107,33 @@ export class Engine{
       return;
     }
 
-    if(step.type==='puzzle' && step.id==='oxygen'){
-      oxygenPuzzle({container, onSolved:(ok)=>{
-        if(ok) this.score++;
-        this.stepIndex++;
-        if(this.stepIndex >= this.chapter.steps.length) this.end(); else this.render();
-      }});
-      return;
+    if(step.type==='puzzle'){
+      if(step.id==='oxygen'){
+        oxygenPuzzle({container, onSolved:(ok)=>{
+          if(ok) this.score++;
+          this.stepIndex++;
+          if(this.stepIndex >= this.chapter.steps.length) this.end(); else this.render();
+        }});
+        return;
+      }
+
+      if(step.id==='quickfire'){
+        quickfirePuzzle({container, onSolved:(ok)=>{
+          if(ok) this.score++;
+          this.stepIndex++;
+          if(this.stepIndex >= this.chapter.steps.length) this.end(); else this.render();
+        }});
+        return;
+      }
+
+      if(step.id==='treasure-chest'){
+        treasureChestPuzzle({container, onSolved:(ok)=>{
+          if(ok) this.score++;
+          this.stepIndex++;
+          if(this.stepIndex >= this.chapter.steps.length) this.end(); else this.render();
+        }});
+        return;
+      }
     }
   }
 }

--- a/math-rpg/src/game/puzzles/quickfire.js
+++ b/math-rpg/src/game/puzzles/quickfire.js
@@ -1,0 +1,99 @@
+import { speak, narrationEnabled } from '../../tts.js';
+
+export function quickfirePuzzle({ container, onSolved }) {
+  const tasks = [
+    {
+      prompt: 'Gauge 3B spikes to 28 litres of water per minute. You drop a valve that bleeds away 9 litres instantly. What flow remains?',
+      answer: 19,
+      hint: 'Subtract 9 from 28.'
+    },
+    {
+      prompt: 'Two backup pumps blast 6 litres each per minute. The control screen insists you need 27 litres to hold the corridor. How many litres must the main pump add?',
+      answer: 15,
+      hint: 'Add the two pumps together, then find the difference to 27.'
+    },
+    {
+      prompt: 'A jammed sluice divides the tunnel into 3 equal channels. Each must carry 12 litres of water to keep the flood steady. What total flow should roar through the gate?',
+      answer: 36,
+      hint: 'Multiply 12 by 3.'
+    }
+  ];
+
+  let index = 0;
+
+  container.innerHTML = `
+    <p class="prompt">Emergency sirens echo. You have seconds to stabilise the waterworks.</p>
+    <p class="meta">Quickfire round: answer each calculation to seal the valves. There are ${tasks.length} tasks.</p>
+    <p id="q-status" class="meta" aria-live="polite"></p>
+    <label class="quickfire-question">
+      <span id="q-text"></span>
+      <input id="q-input" type="number" inputmode="numeric" class="answer" aria-label="Enter your answer">
+    </label>
+    <div class="controls" style="margin-top:10px">
+      <button id="q-submit" class="primary">Lock In</button>
+    </div>
+    <div id="feedback" class="feedback" aria-live="polite"></div>
+  `;
+
+  const status = container.querySelector('#q-status');
+  const question = container.querySelector('#q-text');
+  const input = container.querySelector('#q-input');
+  const submit = container.querySelector('#q-submit');
+  const feedback = container.querySelector('#feedback');
+
+  function updateView() {
+    const current = tasks[index];
+    status.textContent = `Task ${index + 1} of ${tasks.length}`;
+    question.textContent = current.prompt;
+    input.value = '';
+    if (narrationEnabled()) speak(current.prompt);
+    input.focus();
+  }
+
+  function handleSuccess() {
+    feedback.textContent = 'Valves stabilised! You outrun the surge.';
+    feedback.className = 'feedback good';
+    if (narrationEnabled()) speak('Valves stabilised.');
+    submit.disabled = true;
+    input.disabled = true;
+    setTimeout(() => onSolved(true), 900);
+  }
+
+  function handleCheck() {
+    const current = tasks[index];
+    const val = Number(input.value);
+    if (Number.isNaN(val)) {
+      feedback.textContent = 'Enter a number before locking in.';
+      feedback.className = 'feedback bad';
+      if (narrationEnabled()) speak('Enter a number.');
+      return;
+    }
+
+    if (val === current.answer) {
+      feedback.textContent = 'Quick thinking!';
+      feedback.className = 'feedback good';
+      if (narrationEnabled()) speak('Correct.');
+      index += 1;
+      if (index >= tasks.length) {
+        handleSuccess();
+      } else {
+        setTimeout(() => {
+          feedback.textContent = '';
+          feedback.className = 'feedback';
+          updateView();
+        }, 500);
+      }
+    } else {
+      feedback.textContent = `${current.hint}`;
+      feedback.className = 'feedback bad';
+      if (narrationEnabled()) speak('Not quite. Try again.');
+    }
+  }
+
+  submit.addEventListener('click', handleCheck);
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') handleCheck();
+  });
+
+  updateView();
+}

--- a/math-rpg/src/game/puzzles/treasureChest.js
+++ b/math-rpg/src/game/puzzles/treasureChest.js
@@ -1,0 +1,59 @@
+import { speak, narrationEnabled } from '../../tts.js';
+
+export function treasureChestPuzzle({ container, onSolved }) {
+  container.innerHTML = `
+    <p class="prompt">The chest hums with tidal glyphs. Three brass dials labelled Tide, Current, and Anchor glow with faint numbers.</p>
+    <p class="meta">Etched beside them: "Anchor equals the number of seasons in a year. Tide is three times Anchor. Current is Tide minus Anchor. Enter the four-digit code as Anchor, Tide, then Current."</p>
+    <label>
+      Enter the code:
+      <input id="chest-code" type="number" inputmode="numeric" class="answer" aria-label="Enter the treasure code">
+    </label>
+    <div class="controls" style="margin-top:10px">
+      <button id="chest-check" class="primary">Open Chest</button>
+    </div>
+    <div id="feedback" class="feedback" aria-live="polite"></div>
+  `;
+
+  const input = container.querySelector('#chest-code');
+  const check = container.querySelector('#chest-check');
+  const feedback = container.querySelector('#feedback');
+  let resolved = false;
+
+  function lockControls() {
+    resolved = true;
+    input.disabled = true;
+    check.disabled = true;
+  }
+
+  function evaluate() {
+    if (resolved) return;
+    const value = Number(input.value);
+    if (Number.isNaN(value)) {
+      feedback.textContent = 'Type the full code before trying the chest.';
+      feedback.className = 'feedback bad';
+      if (narrationEnabled()) speak('Type the full code.');
+      return;
+    }
+
+    lockControls();
+
+    if (value === 4128) {
+      feedback.textContent = 'The chest clicks open! A glowing Tidecloak badge shimmers into your inventory.';
+      feedback.className = 'feedback good';
+      if (narrationEnabled()) speak('Chest open. Tidecloak badge unlocked.');
+      setTimeout(() => onSolved(true), 1000);
+    } else {
+      feedback.textContent = 'The glyphs flare angry red. The chest bursts in a splash of foam and vanishes—you duck and press on!';
+      feedback.className = 'feedback bad';
+      if (narrationEnabled()) speak('The chest explodes. You move on.');
+      setTimeout(() => onSolved(false), 1200);
+    }
+  }
+
+  check.addEventListener('click', evaluate);
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') evaluate();
+  });
+
+  setTimeout(() => input?.focus(), 50);
+}


### PR DESCRIPTION
## Summary
- extend the first chapter with a new valve quickfire puzzle and treasure chest encounter
- integrate the new puzzles into the game engine alongside revised story beats
- reward correct chest solutions with a cosmetic badge while allowing progress after an incorrect attempt

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbc74d3e6c832f9f46d3496c52e280