### PR TITLE
Add branded KS toggle, refreshed narrative, and accessibility polish

### DIFF
--- a/math-rpg/README.md
+++ b/math-rpg/README.md
@@ -5,8 +5,9 @@ Self‑contained, vanilla JS project to prototype your Math‑RPG. No build tool
 ## What’s here
 - **Separated structure** for easy expansion (chapters, puzzles, UI, a11y).
 - **Narration + TTS** (toggleable).
-- **Chapter 1**: short intro + 3 starter challenges (fight, lock, oxygen puzzle).
-- **Accessible**: keyboard friendly, large type, ARIA live regions, high‑contrast mode.
+- **Key Stage toggle** at the top of the screen instantly swaps KS3 / KS4 question sets and updates the HUD.
+- **Chapter 1**: refreshed story flow + 3 starter challenges (fight, lock, oxygen puzzle) with a live score tracker.
+- **Accessible**: keyboard friendly, large type, ARIA live regions, high‑contrast mode, screen‑reader hints.
 
 ## Run
 1. Download and unzip.

--- a/math-rpg/index.html
+++ b/math-rpg/index.html
@@ -8,16 +8,34 @@
 </head>
 <body>
   <header class="app-header" role="banner">
-    <img src="./public/assets/images/logo.svg" alt="" class="logo" aria-hidden="true">
-    <h1 id="game-title">Math‑RPG</h1>
-    <div class="toggles">
+    <div class="brand">
+      <img src="./public/assets/images/logo.svg" alt="Pencoedtre High School crest" class="logo">
+      <div class="brand-copy">
+        <h1 id="game-title">Pencoedtre Numeracy Quest</h1>
+        <p class="tagline">Flooded Ruins training mission</p>
+      </div>
+    </div>
+    <div class="toggles" role="group" aria-label="Game options">
+      <div class="stage-toggle">
+        <label for="stage-select">Key Stage</label>
+        <p id="stage-desc" class="sr-only">Switch between Key Stage 3 and Key Stage 4 questions.</p>
+        <select id="stage-select" aria-describedby="stage-desc">
+          <option value="ks3">KS3 Explorer</option>
+          <option value="ks4">KS4 Vanguard</option>
+        </select>
+      </div>
       <button id="tts-toggle" aria-pressed="true" title="Toggle narration (T)">🔊 Narration</button>
       <button id="hc-toggle" aria-pressed="false" title="Toggle high contrast (H)">🌓 High contrast</button>
     </div>
   </header>
 
   <main id="app" class="app" role="main">
-    <section id="screen" class="screen" aria-live="polite" aria-atomic="true"></section>
+    <section id="screen" class="screen" aria-live="polite" aria-atomic="true" tabindex="-1"></section>
+    <div class="hud" aria-live="polite" aria-atomic="true">
+      <span id="mode-badge" class="badge">Key Stage 3 Explorer</span>
+      <span id="progress-badge" class="badge">Scene 1 of 9</span>
+      <span id="score-badge" class="badge">Score 0 / 0</span>
+    </div>
     <nav class="controls" aria-label="Game controls">
       <button id="next-btn" class="primary">Continue ▸</button>
       <button id="restart-btn" class="secondary">Restart</button>
@@ -25,7 +43,7 @@
   </main>
 
   <footer class="app-footer">
-    <p><kbd>Enter</kbd>/<kbd>Space</kbd> continue • <kbd>1‑4</kbd> answer • <kbd>T</kbd> narration • <kbd>H</kbd> high contrast</p>
+    <p><kbd>Enter</kbd>/<kbd>Space</kbd> continue • <kbd>1‑4</kbd> answer • <kbd>T</kbd> narration • <kbd>H</kbd> high contrast • Key Stage select for KS3/KS4</p>
   </footer>
 
   <script type="module" src="./src/main.js"></script>

--- a/math-rpg/public/assets/images/logo.svg
+++ b/math-rpg/public/assets/images/logo.svg
@@ -1,11 +1,30 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240" role="img" aria-labelledby="logoTitle logoDesc">
+  <title id="logoTitle">Pencoedtre High School crest</title>
+  <desc id="logoDesc">A gold-edged shield with a green tree above a banner reading Pencoedtre.</desc>
   <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#00ff72"/>
-      <stop offset="1" stop-color="#3bd16f"/>
+    <linearGradient id="shieldFill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#11181f"/>
+      <stop offset="1" stop-color="#0a1016"/>
+    </linearGradient>
+    <linearGradient id="treeFill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#63d87c"/>
+      <stop offset="1" stop-color="#2b8f4a"/>
+    </linearGradient>
+    <linearGradient id="bannerFill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#f2c54a"/>
+      <stop offset="1" stop-color="#dba930"/>
     </linearGradient>
   </defs>
-  <rect width="96" height="96" rx="20" fill="#0c141f"/>
-  <circle cx="48" cy="48" r="30" fill="url(#g)" opacity=".15"/>
-  <path d="M24 60h14l-7-24 20 34 9-18h12" stroke="url(#g)" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <g transform="translate(12 12)">
+    <path d="M32 12h112c9 0 16 7 16 16v74c0 54-60 94-72 101-12-7-72-47-72-101V28c0-9 7-16 16-16z" fill="url(#shieldFill)" stroke="#f7d874" stroke-width="6" stroke-linejoin="round"/>
+    <g transform="translate(52 36)">
+      <path d="M48 92c-14-9-26-21-30-39 8 11 14 15 18 16-8-16-10-33-5-52 3 18 12 33 26 42-2-10-2-20 3-32 3 11 6 20 14 29-1-9 1-18 6-28 2 17 0 32-8 45 4 0 10-4 16-11-4 14-14 26-28 35v24h-12z" fill="url(#treeFill)"/>
+      <path d="M52 94h-4V68c-12-8-20-17-24-26 5 5 10 8 15 10-6-13-7-27-3-43 1 16 9 31 23 42-2-12-1-23 4-34 3 12 6 22 14 33-1-9 0-18 4-27 1 14 0 26-6 38 5-2 11-6 16-12-5 12-13 22-26 31z" fill="#174d2b" opacity=".6"/>
+      <path d="M48 96h8c1 10-3 16-8 16s-9-6-8-16z" fill="#2b8f4a"/>
+    </g>
+    <g transform="translate(0 150)">
+      <path d="M16 22h144l16-22v46l-16-8H16L0 46V24z" fill="url(#bannerFill)" stroke="#1b1b1b" stroke-width="4" stroke-linejoin="round"/>
+      <text x="88" y="32" fill="#161616" font-family="'Montserrat','Segoe UI',sans-serif" font-size="26" font-weight="700" text-anchor="middle" letter-spacing="3">PENCOEDTRE</text>
+    </g>
+  </g>
 </svg>

--- a/math-rpg/public/styles/main.css
+++ b/math-rpg/public/styles/main.css
@@ -1,68 +1,198 @@
 /* Theme */
 :root{
-  --bg:#0b0f14;
-  --panel:#121923;
-  --panel-2:#0f1620;
-  --text:#eaf2ff;
-  --muted:#a7b3c7;
-  --accent:#3bd16f; /* Pencoedtre‑ish green vibe */
-  --warn:#ffb02e;
+  --bg:#050608;
+  --bg-accent:#0a111d;
+  --panel:#0f1724;
+  --panel-2:#141e2d;
+  --panel-3:#1a2536;
+  --text:#f6fbff;
+  --muted:#b9c8dd;
+  --accent:#38d67a;
+  --accent-strong:#7ef7aa;
+  --brand-gold:#f5c545;
+  --brand-green:#2f9a55;
   --bad:#ff5a5a;
   --good:#39d353;
-  --focus: #7aa6ff;
-  --radius:16px;
-  --font: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, 'Noto Sans', Arial, sans-serif;
+  --focus:#f5c545;
+  --radius:18px;
+  --font: "Nunito", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans", Arial, sans-serif;
 }
 body.high-contrast{
   --bg:#000;
+  --bg-accent:#000;
   --panel:#000;
   --panel-2:#000;
+  --panel-3:#000;
   --text:#fff;
-  --muted:#ddd;
+  --muted:#f0f0f0;
   --accent:#00ff72;
+  --accent-strong:#9affb8;
+  --brand-gold:#ffe37a;
+  --brand-green:#00c061;
   --focus:#fff;
 }
 
 *{box-sizing:border-box}
 html,body{height:100%}
 body{
-  margin:0;background:linear-gradient(180deg,var(--bg),#06080c 60%);
-  color:var(--text);font-family:var(--font);line-height:1.35;
-  display:flex;flex-direction:column;min-height:100%;
+  margin:0;
+  background:radial-gradient(circle at top,var(--brand-green) -20%,transparent 35%),linear-gradient(180deg,var(--bg),var(--bg-accent) 55%,#030406 100%);
+  color:var(--text);
+  font-family:var(--font);
+  line-height:1.5;
+  display:flex;
+  flex-direction:column;
+  min-height:100%;
 }
-.app-header,.app-footer{padding:12px 16px;background:transparent}
-.app-header{display:flex;align-items:center;gap:12px;justify-content:space-between}
-.logo{width:40px;height:40px;opacity:.9}
-#game-title{margin:0;font-size:1.4rem;letter-spacing:.5px}
-.toggles button{margin-left:8px}
+.app-header,.app-footer{padding:16px 20px;background:transparent}
+.app-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:18px;
+  background:linear-gradient(135deg,rgba(20,33,46,.95),rgba(15,27,38,.9));
+  border-bottom:1px solid rgba(245,197,69,.25);
+  box-shadow:0 10px 25px rgba(0,0,0,.35);
+}
+.brand{display:flex;align-items:center;gap:16px}
+.logo{width:58px;height:58px;flex-shrink:0;filter:drop-shadow(0 4px 10px rgba(0,0,0,.4))}
+.brand-copy{display:flex;flex-direction:column;gap:4px}
+#game-title{margin:0;font-size:1.75rem;letter-spacing:.8px;font-weight:800;text-transform:uppercase}
+.tagline{margin:0;font-size:.95rem;color:var(--accent-strong);font-weight:600;letter-spacing:.6px;text-transform:uppercase}
 
-.app{max-width:900px;margin:0 auto;padding:16px;flex:1;width:100%}
+.toggles{display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap;justify-content:flex-end}
+.stage-toggle{display:flex;flex-direction:column;gap:4px;min-width:150px}
+.stage-toggle label{font-size:.85rem;font-weight:700;text-transform:uppercase;letter-spacing:.5px;color:var(--brand-gold)}
+#stage-select{
+  appearance:none;
+  border-radius:12px;
+  border:1px solid rgba(245,197,69,.45);
+  background:linear-gradient(180deg,var(--panel-3),var(--panel));
+  color:var(--text);
+  padding:10px 36px 10px 12px;
+  font-weight:600;
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.35);
+  position:relative;
+  min-height:44px;
+}
+#stage-select:focus-visible{outline:3px solid var(--focus);outline-offset:2px}
+
+.app{max-width:980px;margin:0 auto;padding:28px 24px 40px 24px;flex:1;width:100%}
 .screen{
   background:linear-gradient(180deg,var(--panel),var(--panel-2));
-  border:1px solid #1e2633;border-radius:var(--radius);
-  padding:20px;min-height:280px;box-shadow:0 10px 30px rgba(0,0,0,.3);
+  border:1px solid rgba(245,197,69,.25);
+  border-radius:var(--radius);
+  padding:28px 28px 32px 28px;
+  min-height:320px;
+  box-shadow:0 24px 60px rgba(3,7,12,.55);
+  outline:none;
 }
-.controls{display:flex;gap:10px;margin-top:14px}
+.screen:focus-visible{box-shadow:0 0 0 3px var(--focus);}
+
+.hud{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  margin:18px 0 6px 0;
+}
+
+.controls{display:flex;gap:12px;margin-top:14px;flex-wrap:wrap}
 button{
-  border-radius:12px;border:1px solid #2a3547;background:#16202e;color:var(--text);
-  padding:10px 14px;font-weight:600;cursor:pointer;transition:.2s transform, .2s background, .2s border;
+  border-radius:14px;
+  border:1px solid rgba(245,197,69,.4);
+  background:linear-gradient(180deg,var(--panel-3),var(--panel));
+  color:var(--text);
+  padding:12px 18px;
+  font-weight:700;
+  cursor:pointer;
+  transition:transform .18s ease,box-shadow .18s ease,border .18s ease;
+  min-height:48px;
 }
-button:hover{transform:translateY(-1px);border-color:#3a4b66}
-button.primary{background:linear-gradient(180deg,#1b2a3d,#132032);border-color:#30405a}
-button.secondary{background:#0d141d}
-button[disabled]{opacity:.6;cursor:not-allowed}
+button:hover{transform:translateY(-2px);box-shadow:0 10px 24px rgba(0,0,0,.35);border-color:var(--brand-gold)}
+button:focus-visible{outline:3px solid var(--focus);outline-offset:2px}
+button.primary{background:linear-gradient(180deg,var(--brand-green),#0d321f);border-color:rgba(56,214,122,.6)}
+button.secondary{background:linear-gradient(180deg,var(--panel-3),var(--panel-2));}
+button[disabled]{opacity:.6;cursor:not-allowed;transform:none;box-shadow:none}
 
-.choice-list{display:grid;gap:10px;margin-top:12px}
-.choice-list button{justify-content:flex-start}
-.choice-list kbd{background:#0002;border:1px solid #ffffff20;border-radius:6px;padding:2px 6px;margin-right:8px}
+.choice-list{display:grid;gap:12px;margin-top:16px}
+.choice-list button{
+  justify-content:flex-start;
+  display:flex;
+  gap:14px;
+  align-items:center;
+  font-size:1.05rem;
+  text-align:left;
+}
+.choice-key kbd{border:1px solid rgba(245,197,69,.35);background:rgba(0,0,0,.35);padding:4px 10px;border-radius:10px;font-size:.9rem;font-weight:700}
+.choice-text{flex:1;font-weight:700;letter-spacing:.2px}
 
-.prompt{font-size:1.2rem;margin:0 0 6px 0}
-.meta{color:var(--muted);font-size:.95rem;margin:0 0 12px 0}
-.feedback{margin-top:10px;font-weight:700}
+.prompt{font-size:1.3rem;margin:0 0 8px 0;font-weight:800;letter-spacing:.4px}
+.meta{color:var(--muted);font-size:1rem;margin:0 0 14px 0;font-weight:600}
+.feedback{margin-top:12px;font-weight:800}
 .feedback.good{color:var(--good)}
 .feedback.bad{color:var(--bad)}
-.badge{display:inline-block;background:#ffffff12;border:1px solid #ffffff20;border-radius:12px;padding:4px 10px;margin:6px 0}
+.badge{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  background:linear-gradient(135deg,rgba(56,214,122,.18),rgba(245,197,69,.15));
+  border:1px solid rgba(245,197,69,.4);
+  border-radius:999px;
+  padding:6px 16px;
+  font-weight:700;
+  letter-spacing:.3px;
+}
 
-.code{font-family:ui-monospace,Consolas,Monaco,Menlo,monospace;background:#0003;border-radius:8px;padding:2px 6px}
+#mode-badge::before{content:'🎒';}
+#mode-badge[data-stage="ks4"]::before{content:'🛡️';}
+#mode-badge[data-stage="ks3"]{background:linear-gradient(135deg,rgba(47,154,85,.35),rgba(245,197,69,.15));}
+#mode-badge[data-stage="ks4"]{background:linear-gradient(135deg,rgba(245,197,69,.35),rgba(56,214,122,.15));}
+#progress-badge::before{content:'📘';}
+#score-badge::before{content:'⭐';}
 
-kbd{border:1px solid #ffffff30;border-radius:6px;padding:2px 6px;background:#0004}
+.code{font-family:ui-monospace,Consolas,Monaco,Menlo,monospace;background:rgba(0,0,0,.3);border-radius:10px;padding:3px 8px;font-weight:700}
+
+label{font-weight:700;display:flex;flex-direction:column;gap:6px}
+.answer{
+  border-radius:12px;
+  border:1px solid rgba(245,197,69,.35);
+  padding:10px 12px;
+  background:linear-gradient(180deg,var(--panel-2),var(--panel-3));
+  color:var(--text);
+  font-size:1.05rem;
+}
+.answer:focus-visible{outline:3px solid var(--focus);outline-offset:2px}
+
+.app-footer{color:var(--muted);font-size:.95rem;text-align:center}
+
+.sr-only{
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  white-space:nowrap;
+  border:0;
+}
+
+kbd{border:1px solid rgba(245,197,69,.3);border-radius:8px;padding:3px 6px;background:rgba(0,0,0,.35);font-weight:700}
+
+@media (max-width:840px){
+  .app-header{flex-direction:column;align-items:flex-start;border-radius:0 0 24px 24px}
+  .toggles{width:100%;justify-content:flex-start}
+  .app{padding:24px 18px 32px 18px}
+}
+
+@media (max-width:600px){
+  #game-title{font-size:1.35rem}
+  .logo{width:48px;height:48px}
+  .screen{padding:22px 18px}
+}
+
+body.high-contrast button{border-color:#fff;background:#000}
+body.high-contrast .screen{border-color:#fff;box-shadow:none}
+body.high-contrast .badge{border-color:#fff;background:#000;color:#fff}
+body.high-contrast .choice-key kbd{border-color:#fff;background:#000;color:#fff}
+body.high-contrast .app-header{background:#000;border-color:#fff;box-shadow:none}

--- a/math-rpg/src/game/chapters/chapter1.js
+++ b/math-rpg/src/game/chapters/chapter1.js
@@ -1,75 +1,125 @@
-export const chapter1 = {
+const baseSteps = [
+  {
+    type: 'narrative',
+    text: 'Rain rattles the steel gantry above the reservoir as you fasten the <strong>Pencoedtre crest</strong> to your dive suit. Below, a numeracy beacon sputters in the Flooded Ruins.',
+    meta: 'Press Continue to descend the hatch.'
+  },
+  {
+    type: 'narrative',
+    text: 'You drop into the Drowned Observatory. Luminous vine guardians slither awake, tasting the charge of your calculator glove.',
+    meta: 'Solve fast to strike before they constrict.'
+  },
+  {
+    type: 'q-mcq',
+    variants: {
+      ks3: {
+        question: 'A vine hurls 18 glowing thorns. You deflect 7 with your shield. How many thorns still flicker?',
+        meta: 'Subtract to sap its strength.',
+        choices: [
+          { label: '9', correct: false, feedback: 'Nine would mean the vine only launched 16 thorns.' },
+          { label: '10', correct: false, feedback: 'Check the subtraction carefully.' },
+          { label: '11', correct: true, feedback: 'Direct hit! Eleven thorns remain.' },
+          { label: '12', correct: false, feedback: 'Too many—keep counting.' }
+        ]
+      },
+      ks4: {
+        question: 'The guardian splits its energy into 3 coils of 4 sparks each and unleashes 5 spare sparks. How many sparks surge altogether?',
+        meta: 'Use multiplication, then add the strays.',
+        choices: [
+          { label: '12', correct: false, feedback: 'That is only the energy from the coils.' },
+          { label: '15', correct: false, feedback: 'Remember the spare sparks as well.' },
+          { label: '17', correct: true, feedback: 'All sparks counted—your strike lands!' },
+          { label: '19', correct: false, feedback: 'Too many sparks—double-check the totals.' }
+        ]
+      }
+    }
+  },
+  {
+    type: 'narrative',
+    text: 'The vines recoil and the crest on your chest glows warm. Sirens pulse as flood gauges spike red along the corridor.',
+    meta: 'Stabilise the valves before the tunnels drown.'
+  },
+  {
+    type: 'puzzle',
+    id: 'quickfire'
+  },
+  {
+    type: 'narrative',
+    text: 'With the pumps steady, a brass bulkhead seals the passage. Its keypad shines with tidal runes awaiting the correct code.',
+    meta: 'Read the pattern and enter the digits.'
+  },
+  {
+    type: 'q-mcq',
+    variants: {
+      ks3: {
+        question: 'The keypad shows 4 crates with 6 glowrods each and 8 loose rods beside them. What code unlocks the door?',
+        meta: 'Multiply, then add the extras.',
+        choices: [
+          { label: '24', correct: false, feedback: 'That is only the rods in the crates.' },
+          { label: '28', correct: false, feedback: 'Add the loose rods too.' },
+          { label: '32', correct: true, feedback: 'Door slides open with a hiss.' },
+          { label: '38', correct: false, feedback: 'Too high—count again.' }
+        ]
+      },
+      ks4: {
+        question: 'A schematic glows with 2 × (3x + 4) when x = 5. Enter the code that balances the circuits.',
+        meta: 'Evaluate inside the brackets before multiplying.',
+        choices: [
+          { label: '22', correct: false, feedback: 'Try substituting x = 5 again.' },
+          { label: '34', correct: false, feedback: 'Double-check your multiplication.' },
+          { label: '38', correct: true, feedback: 'Runes align—the bulkhead unlocks.' },
+          { label: '44', correct: false, feedback: 'Slightly too high—check the order of operations.' }
+        ]
+      }
+    }
+  },
+  {
+    type: 'narrative',
+    text: 'Beyond the bulkhead rests a tide-scarred chest ringed in bioluminescent barnacles. Your crest senses an artefact reward within.',
+    meta: 'Match the glyphs to win the Tidecloak badge.'
+  },
+  {
+    type: 'puzzle',
+    id: 'treasure-chest'
+  },
+  {
+    type: 'narrative',
+    text: 'The chamber drains into a narrow tunnel that burbles with black water. A battered oxygen tank floats beside the entrance.',
+    meta: 'Plan your swim before the gauge runs dry.'
+  },
+  {
+    type: 'puzzle',
+    id: 'oxygen'
+  },
+  {
+    type: 'narrative',
+    text: 'You surface in a lantern-lit cavern, crest gleaming. The numeracy beacon hums back to life ahead, inviting the next stage of the quest.',
+    meta: 'Chapter 1 complete—log your score and brief your team.'
+  }
+];
+
+function resolveStep(step, stage){
+  if(step.variants){
+    const variant = step.variants[stage] || step.variants.ks3;
+    const { variants, ...rest } = step;
+    return Object.freeze({ ...rest, ...variant });
+  }
+  return Object.freeze({ ...step });
+}
+
+export function buildChapter1({ stage = 'ks3' } = {}){
+  const keyStage = stage === 'ks4' ? 'ks4' : 'ks3';
+  const steps = baseSteps.map(step => resolveStep(step, keyStage));
+  return Object.freeze({
+    id: 'chapter1',
+    title: 'Into the Flooded Ruins',
+    stage: keyStage,
+    steps: Object.freeze(steps)
+  });
+}
+
+export default Object.freeze({
   id: 'chapter1',
   title: 'Into the Flooded Ruins',
-  steps: [
-    {
-      type: 'narrative',
-      text: 'You choose your adventurer and step into the flooded ruins. Your torch flickers as water drips from the ceiling.',
-      meta: 'Press Continue.'
-    },
-    {
-      type: 'narrative',
-      text: 'A shambling vine-beast blocks your path. It lunges! Solve fast to strike first.',
-      meta: 'Quick duel math.'
-    },
-    {
-      type: 'q-mcq',
-      question: '12 + 7 = ?',
-      choices: [
-        { label: '18', correct: false, feedback: 'Too low.' },
-        { label: '19', correct: true, feedback: 'Nice hit!' },
-        { label: '20', correct: false, feedback: 'Close, but no.' },
-        { label: '21', correct: false, feedback: 'Too high.' }
-      ]
-    },
-    {
-      type: 'narrative',
-      text: 'The beast withers. Water sirens flash as the tunnel starts flooding faster around you.',
-      meta: 'Stabilise the valves before the corridor fills.'
-    },
-    {
-      type: 'puzzle',
-      id: 'quickfire'
-    },
-    {
-      type: 'narrative',
-      text: 'With the pressure settled, a rusted door stands ahead with a number pad.',
-      meta: 'Crack the lock.'
-    },
-    {
-      type: 'q-mcq',
-      question: 'The code equals 3 × (6 + 4). Enter the result:',
-      choices: [
-        { label: '30', correct: true, feedback: 'Door clicks open.' },
-        { label: '24', correct: false, feedback: 'Remember the brackets first.' },
-        { label: '34', correct: false, feedback: 'Order of operations!' },
-        { label: '46', correct: false, feedback: 'Way off.' }
-      ]
-    },
-    {
-      type: 'narrative',
-      text: 'Inside the chamber a barnacled treasure chest pulses with blue light.',
-      meta: 'The glyphs promise a cosmetic badge for the right code.'
-    },
-    {
-      type: 'puzzle',
-      id: 'treasure-chest'
-    },
-    {
-      type: 'narrative',
-      text: 'Whether the chest rewards you or explodes in spray, you press deeper into the ruins. A submerged tunnel gurgles nearby and an oxygen tank lies within reach.',
-      meta: 'Time your swim.'
-    },
-    {
-      type: 'puzzle',
-      id: 'oxygen'
-    },
-    {
-      type: 'narrative',
-      text: 'You surface safe on the far side, water streaming off your gear. A faint glow beckons deeper within…',
-      meta: 'Chapter 1 complete.'
-    }
-  ]
-};
-
-export default Object.freeze(chapter1);
+  build: buildChapter1
+});

--- a/math-rpg/src/game/chapters/index.js
+++ b/math-rpg/src/game/chapters/index.js
@@ -1,15 +1,15 @@
-import chapter1 from './chapter1.js';
+import { buildChapter1 } from './chapter1.js';
 
 const chapters = Object.freeze({
-  [chapter1.id]: chapter1
+  chapter1: buildChapter1
 });
 
 export const chapterIds = Object.freeze(Object.keys(chapters));
 
-export function getChapter(name){
-  const chapter = chapters[name];
-  if(!chapter){
+export function getChapter(name, options={}){
+  const builder = chapters[name];
+  if(!builder){
     throw new Error(`Chapter "${name}" not found`);
   }
-  return chapter;
+  return builder(options);
 }

--- a/math-rpg/src/game/puzzles/oxygen.js
+++ b/math-rpg/src/game/puzzles/oxygen.js
@@ -2,11 +2,12 @@ import { speak, narrationEnabled } from '../../tts.js';
 
 export function oxygenPuzzle({container, onSolved}){
   container.innerHTML = `
-    <p class="prompt">To reach the next area you must swim through a tunnel using an oxygen tank.</p>
+    <p class="prompt" role="heading" aria-level="2">To reach the next area you must swim through a tunnel using an oxygen tank.</p>
     <p class="meta">The tank is full. It drains at <span class="code">1% per second</span>. Crossing will use <span class="code">25%</span> of the tank.</p>
+    <p id="oxygen-instructions" class="sr-only">Type the number of seconds, then press the check button or Enter.</p>
     <label>
       How many seconds will it take?
-      <input id="ans" type="number" inputmode="numeric" class="answer" aria-label="Enter seconds">
+      <input id="ans" type="number" inputmode="numeric" class="answer" aria-label="Enter seconds" aria-describedby="oxygen-instructions">
     </label>
     <div class="controls" style="margin-top:10px">
       <button id="check" class="primary">Check</button>

--- a/math-rpg/src/game/puzzles/quickfire.js
+++ b/math-rpg/src/game/puzzles/quickfire.js
@@ -22,12 +22,13 @@ export function quickfirePuzzle({ container, onSolved }) {
   let index = 0;
 
   container.innerHTML = `
-    <p class="prompt">Emergency sirens echo. You have seconds to stabilise the waterworks.</p>
+    <p class="prompt" role="heading" aria-level="2">Emergency sirens echo. You have seconds to stabilise the waterworks.</p>
     <p class="meta">Quickfire round: answer each calculation to seal the valves. There are ${tasks.length} tasks.</p>
     <p id="q-status" class="meta" aria-live="polite"></p>
+    <p id="quickfire-instructions" class="sr-only">Type the answer, then press the lock in button or Enter to submit.</p>
     <label class="quickfire-question">
       <span id="q-text"></span>
-      <input id="q-input" type="number" inputmode="numeric" class="answer" aria-label="Enter your answer">
+      <input id="q-input" type="number" inputmode="numeric" class="answer" aria-label="Enter your answer" aria-describedby="quickfire-instructions">
     </label>
     <div class="controls" style="margin-top:10px">
       <button id="q-submit" class="primary">Lock In</button>

--- a/math-rpg/src/game/puzzles/treasureChest.js
+++ b/math-rpg/src/game/puzzles/treasureChest.js
@@ -2,11 +2,12 @@ import { speak, narrationEnabled } from '../../tts.js';
 
 export function treasureChestPuzzle({ container, onSolved }) {
   container.innerHTML = `
-    <p class="prompt">The chest hums with tidal glyphs. Three brass dials labelled Tide, Current, and Anchor glow with faint numbers.</p>
+    <p class="prompt" role="heading" aria-level="2">The chest hums with tidal glyphs. Three brass dials labelled Tide, Current, and Anchor glow with faint numbers.</p>
     <p class="meta">Etched beside them: "Anchor equals the number of seasons in a year. Tide is three times Anchor. Current is Tide minus Anchor. Enter the four-digit code as Anchor, Tide, then Current."</p>
+    <p id="chest-instructions" class="sr-only">Enter all four digits together, then press the open chest button or Enter.</p>
     <label>
       Enter the code:
-      <input id="chest-code" type="number" inputmode="numeric" class="answer" aria-label="Enter the treasure code">
+      <input id="chest-code" type="number" inputmode="numeric" class="answer" aria-label="Enter the treasure code" aria-describedby="chest-instructions">
     </label>
     <div class="controls" style="margin-top:10px">
       <button id="chest-check" class="primary">Open Chest</button>

--- a/math-rpg/src/main.js
+++ b/math-rpg/src/main.js
@@ -1,5 +1,5 @@
 import { Engine } from './game/engine.js';
-import { toggleNarration } from './tts.js';
+import { toggleNarration, narrationEnabled, speak } from './tts.js';
 import { getChapter } from './game/chapters/index.js';
 
 function toggleHighContrast(btn){
@@ -14,8 +14,12 @@ function init(){
   const restartBtn = document.getElementById('restart-btn');
   const ttsBtn = document.getElementById('tts-toggle');
   const hcBtn = document.getElementById('hc-toggle');
+  const stageSelect = document.getElementById('stage-select');
+  const modeBadge = document.getElementById('mode-badge');
+  const progressBadge = document.getElementById('progress-badge');
+  const scoreBadge = document.getElementById('score-badge');
 
-  if(!screen || !nextBtn || !restartBtn || !ttsBtn || !hcBtn){
+  if(!screen || !nextBtn || !restartBtn || !ttsBtn || !hcBtn || !stageSelect || !modeBadge || !progressBadge || !scoreBadge){
     throw new Error('Missing required UI elements.');
   }
 
@@ -26,8 +30,50 @@ function init(){
     if(e.key.toLowerCase()==='h') toggleHighContrast(hcBtn);
   });
 
-  const chapter = getChapter('chapter1');
-  new Engine({screen, nextBtn, restartBtn, chapter});
+  const stageLabels = {
+    ks3: 'Key Stage 3 Explorer',
+    ks4: 'Key Stage 4 Vanguard'
+  };
+
+  let currentStage = (stageSelect?.value || 'ks3').toLowerCase() === 'ks4' ? 'ks4' : 'ks3';
+  const chapter = getChapter('chapter1', { stage: currentStage });
+
+  const engine = new Engine({
+    screen,
+    nextBtn,
+    restartBtn,
+    chapter,
+    scoreEl: scoreBadge,
+    progressEl: progressBadge
+  });
+
+  function updateModeBadge(){
+    const label = stageLabels[currentStage] || stageLabels.ks3;
+    modeBadge.textContent = label;
+    modeBadge.setAttribute('aria-label', `Current mode: ${label}`);
+    modeBadge.dataset.stage = currentStage;
+  }
+
+  updateModeBadge();
+
+  function loadStage(stage, {announce=true}={}){
+    currentStage = stageLabels[stage] ? stage : 'ks3';
+    const nextChapter = getChapter('chapter1', { stage: currentStage });
+    engine.setChapter(nextChapter);
+    updateModeBadge();
+    if(announce && narrationEnabled()){
+      speak(`${stageLabels[currentStage]} mode ready.`);
+    }
+  }
+
+  if(stageSelect){
+    stageSelect.value = currentStage;
+    stageSelect.addEventListener('change', (event)=>{
+      const value = (event.target.value || '').toLowerCase();
+      loadStage(value === 'ks4' ? 'ks4' : 'ks3');
+      nextBtn.focus();
+    });
+  }
 }
 
 init();

--- a/math-rpg/src/ui/ui.js
+++ b/math-rpg/src/ui/ui.js
@@ -2,24 +2,29 @@ import { speak } from '../tts.js';
 
 export function renderNarrative({container, text, meta, autoSpeak=true}){
   container.innerHTML = `
-    <p class="prompt">${text}</p>
+    <p class="prompt" role="heading" aria-level="2">${text}</p>
     ${meta ? `<p class="meta">${meta}</p>` : ''}
   `;
   if(autoSpeak) speak(text);
 }
 
-export function renderChoices({container, question, choices}){
+export function renderChoices({container, question, choices, helpText}){
+  const instructionsId = 'choice-instructions';
   container.innerHTML = `
-    <p class="prompt">${question}</p>
-    <div class="choice-list" role="list">
+    <p class="prompt" role="heading" aria-level="2">${question}</p>
+    ${helpText ? `<p class="meta">${helpText}</p>` : ''}
+    <p id="${instructionsId}" class="sr-only">Select an answer with the buttons or press number keys 1 to ${choices.length}.</p>
+    <div class="choice-list" role="list" aria-describedby="${instructionsId}">
       ${choices.map((c,i)=>`
         <button role="listitem" class="choice" data-i="${i}">
-          <kbd>${i+1}</kbd>${c.label}
+          <span class="choice-key"><kbd>${i+1}</kbd></span>
+          <span class="choice-text">${c.label}</span>
         </button>
       `).join('')}
     </div>
     <div id="feedback" class="feedback" aria-live="polite"></div>
   `;
+  speak(question);
 }
 
 export function setFeedback({container, message, good=false}){


### PR DESCRIPTION
## Summary
- restyled the landing layout with a Pencoedtre crest, key stage selector, and live HUD badges for mode, progress, and score.
- rewrote chapter 1 narrative beats and provided separate KS3/KS4 multiple-choice questions while keeping existing puzzles.
- enhanced accessibility with screen-reader guidance, focus management, high-contrast refinements, and a refreshed SVG crest.

## Testing
- No automated tests (static HTML/JS project)


------
https://chatgpt.com/codex/tasks/task_e_68cbf465eb24832f97e224e11cf59654